### PR TITLE
Add dashboard messages view

### DIFF
--- a/frontend/app/components/Api.tsx
+++ b/frontend/app/components/Api.tsx
@@ -10,6 +10,7 @@ import {
   ResourceFormType,
   GenericResponseType,
   ThemeType,
+  UserMessageType,
 } from "../types/types";
 
 const BASE_URL = `${process.env.NEXT_PUBLIC_BACKEND_PROTOCOL}://${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}`;
@@ -49,8 +50,8 @@ class Api {
     return data;
   }
   async get_messages() {
-    const { data } = await this.axios.get<ChatDetailType>(
-      `rag/chat/user_messages`
+    const { data } = await this.axios.get<UserMessageType[]>(
+      `chat/messages/`
     );
     return data;
   }

--- a/frontend/app/components/Sidebar.tsx
+++ b/frontend/app/components/Sidebar.tsx
@@ -67,7 +67,7 @@ const Sidebar = ({ page }: PropTypes) => {
             <User size={22} />
             <span className="text-base">Chat Bots</span>
           </a>
-          {/* <a
+          <a
             href="/dashboard/messages"
             className={`flex items-center justify-center space-x-4 w-full p-5 rounded-full cursor-pointer ${
               page == "messages"
@@ -77,7 +77,7 @@ const Sidebar = ({ page }: PropTypes) => {
           >
             <MessageSquareMore size={22} />
             <span className="text-base">Messages</span>
-          </a> */}
+          </a>
           {/* <a
             href="/dashboard/sales"
             className={`flex items-center justify-center space-x-4 w-full p-5 rounded-full cursor-pointer ${

--- a/frontend/app/dashboard/messages/Messages.tsx
+++ b/frontend/app/dashboard/messages/Messages.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import React, { useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { UserMessageType } from "@/app/types/types";
+
+interface Props {
+  initialData: UserMessageType[];
+  token: string;
+}
+
+const Messages = ({ initialData }: Props) => {
+  const [messages] = useState<UserMessageType[]>(initialData);
+
+  return (
+    <div className="space-y-4">
+      {messages.map((msg, idx) => (
+        <Card key={idx}>
+          <CardHeader className="pb-2">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-x-3">
+                <Avatar>
+                  <AvatarFallback>{msg.username.charAt(0)}</AvatarFallback>
+                </Avatar>
+                <div className="flex flex-col">
+                  <span className="font-medium capitalize">{msg.username}</span>
+                  <span className="text-sm text-muted-foreground">
+                    {msg.chat.name}
+                  </span>
+                </div>
+              </div>
+              <span className="text-xs text-gray-500">{msg.created}</span>
+            </div>
+          </CardHeader>
+          <CardContent className="pt-0 space-y-1">
+            <p>{msg.message}</p>
+            <p className="text-xs text-gray-500">
+              Session: {msg.session_id} · {msg.message_type}
+            </p>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+};
+
+export default Messages;

--- a/frontend/app/dashboard/messages/page.tsx
+++ b/frontend/app/dashboard/messages/page.tsx
@@ -3,17 +3,19 @@ import Layout from "../_layout";
 import Api from "@/app/components/Api";
 import ChatContext from "@/app/hooks/ChatContext";
 import { authToken } from "@/app/components/protected_api";
+import Messages from "./Messages";
 
 const page = async () => {
   const token = await authToken();
   const api = new Api(token);
   const data = await api.get_messages();
-  console.log("Messages data:", data);
 
   return (
     <Layout page="messages">
       <ChatContext token={token}>
-        <div></div>
+        <div className="mx-10 my-5">
+          <Messages initialData={data} token={token} />
+        </div>
       </ChatContext>
     </Layout>
   );

--- a/frontend/app/types/types.ts
+++ b/frontend/app/types/types.ts
@@ -109,6 +109,18 @@ export type MessageType = {
   message_type: string;
   seen: boolean;
 };
+
+export type UserMessageType = {
+  username: string;
+  message: string;
+  message_type: string;
+  session_id: string;
+  created: string;
+  chat: {
+    name: string;
+    slug: string;
+  };
+};
 export type DashboardMessageType = {
   date: string;
   count: number;


### PR DESCRIPTION
## Summary
- add `UserMessageType` for new endpoint response
- update Api helper to call `chat/messages/`
- show messages in dashboard using new component
- expose Messages link in sidebar

## Testing
- `npm run lint` *(fails: `next` not found)*
- `pytest -q` *(fails: ModuleNotFoundError: 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_684da8c91d048329b1204568295b6d5b